### PR TITLE
Fix Mailcow network base to avoid malformed subnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+mailcow-dockerized/
+uv.lock

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run the demo with a single script that installs uv, syncs dependencies, and laun
 ./start_demo.sh
 ```
 
-Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. If the `addmailuser` helper isn't present, the script fetches it from Mailcow's repository using whatever branch your clone checked out (handling both `main` and `master`) so the demo accounts are still created. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
+Add `--mail` to the script to automatically clone Mailcow, start a local stack, and configure the app to relay through it. You'll need to create two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`) yourself via the Mailcow Web UI or API. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
 
 ```bash
 ./start_demo.sh --mail
@@ -135,7 +135,7 @@ If the command attempts to open a browser and you see a `gio: Operation not supp
 
 ### Optional: relay through Mailcow
 
-To show the worm being relayed through a full mail server, you can run a local [Mailcow](https://mailcow.email) instance and point the app at it. The `start_demo.sh --mail` flag automates the setup below (including creation of `demo1@mail.local` and `demo2@mail.local` accounts with password `demo123`), but the steps are provided for reference if you prefer manual control.
+To show the worm being relayed through a full mail server, you can run a local [Mailcow](https://mailcow.email) instance and point the app at it. The `start_demo.sh --mail` flag automates the setup below, but you must create `demo1@mail.local` and `demo2@mail.local` (password `demo123`) yourself.
 
 1. Start Mailcow:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run the demo with a single script that installs uv, syncs dependencies, and laun
 ./start_demo.sh
 ```
 
-Add `--mail` to the script to automatically clone and start a local Mailcow stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
+Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
 
 ```bash
 ./start_demo.sh --mail

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add `--mail` to the script to automatically clone and start a local Mailcow stac
 ./start_demo.sh --mail
 ```
 
-By default the script scans for a free `/24` within the `172.30.0.0/16` range to avoid clashes with existing Docker networks. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network (e.g. `10.99.0`). In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (no trailing `.0`) because the compose file appends `.0/24` automatically. If `docker compose` still reports a subnet overlap, choose a different range and rerun the script.
+By default the script probes for a free `/24` within the `172.30.0.0/16` range by temporarily creating and removing Docker networks, avoiding clashes with both Docker and host subnets. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network (e.g. `10.99.0`). In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (no trailing `.0`) because the compose file appends `.0/24` automatically. If the script still cannot find a free subnet, specify a different range and rerun it.
 
 Press `Ctrl+C` when you're finished with the demo; the script automatically shuts down the Mailcow stack and removes its network to prevent conflicts on the next run.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run the demo with a single script that installs uv, syncs dependencies, and laun
 ./start_demo.sh
 ```
 
-Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. If the `addmailuser` helper isn't present, the script fetches it from Mailcow's repository so the demo accounts are still created. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
+Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. If the `addmailuser` helper isn't present, the script fetches it from Mailcow's repository using whatever branch your clone checked out (handling both `main` and `master`) so the demo accounts are still created. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
 
 ```bash
 ./start_demo.sh --mail

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Add `--mail` to the script to automatically clone and start a local Mailcow stac
 
 By default the script probes for a free `/24` within the `172.30.0.0/16` range by temporarily creating and removing Docker networks, avoiding clashes with both Docker and host subnets. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network (e.g. `10.99.0`). In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (no trailing `.0`) because the compose file appends `.0/24` automatically. If the script still cannot find a free subnet, specify a different range and rerun it.
 
-Press `Ctrl+C` when you're finished with the demo; the script automatically shuts down the Mailcow stack and removes its network to prevent conflicts on the next run.
+If a network named `mailcowdockerized_mailcow-network` is already present, the script assumes Mailcow is running and skips the automatic setup.
+
+Press `Ctrl+C` when you're finished with the demo; if the script started Mailcow, it automatically shuts down the stack and removes its network. Existing Mailcow instances are left untouched.
 
 ### Manual setup
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add `--mail` to the script to automatically clone and start a local Mailcow stac
 ./start_demo.sh --mail
 ```
 
-By default the script assigns Mailcow to the `172.30.1.0/24` subnet to avoid conflicts with existing Docker networks. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR range like `10.99.0.0/24` (and optionally `MAILCOW_IPV4_ADDRESS`) before running if your environment requires a different range.
+By default the script assigns Mailcow to the `172.30.1.0/24` subnet to avoid conflicts with existing Docker networks. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR range like `10.99.0.0/24` (and optionally `MAILCOW_IPV4_ADDRESS`) before running if your environment requires a different range. In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (e.g. `172.30.1` for the default) because the compose file appends `.0/24` automatically.
 
 Press `Ctrl+C` when you're finished with the demo; the script automatically shuts down the Mailcow stack and removes its network to prevent conflicts on the next run.
 
@@ -141,8 +141,8 @@ To show the worm being relayed through a full mail server, you can run a local [
    git clone https://github.com/mailcow/mailcow-dockerized
    cd mailcow-dockerized
    ./generate_config.sh  # answer prompts; use a hostname like mail.local
-   # Optionally edit mailcow.conf to adjust IPV4_NETWORK/IPV4_ADDRESS
-   # if the default 172.22.1.0/24 subnet overlaps with existing networks
+   # Optionally edit mailcow.conf to adjust IPV4_NETWORK (without trailing .0)
+   # and IPV4_ADDRESS if the default 172.22.1.0/24 subnet overlaps with existing networks
    docker compose up -d
    ```
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If the command attempts to open a browser and you see a `gio: Operation not supp
 
 ### Optional: relay through Mailcow
 
-To show the worm being relayed through a full mail server, you can run a local [Mailcow](https://mailcow.email) instance and point the app at it. The `start_demo.sh --mail` flag automates the setup below, but you must create `demo1@mail.local` and `demo2@mail.local` (password `demo123`) yourself.
+To show the worm being relayed through a full mail server, you can run a local [Mailcow](https://mailcow.email) instance and point the app at it. The `start_demo.sh --mail` flag automates the setup below and creates `demo1@mail.local` and `demo2@mail.local` (password `demo123`) for you.
 
 1. Start Mailcow:
 
@@ -148,12 +148,7 @@ To show the worm being relayed through a full mail server, you can run a local [
    docker compose up -d
    ```
 
-2. Create two mailboxes to watch the worm spread:
-
-   - Visit `https://mailcow.localhost` (or the hostname you set in `mailcow.conf`).
-   - Sign in to the admin UI (default credentials `admin` / `moohoo`).
-   - Add `demo1@mail.local` and `demo2@mail.local` with password `demo123`.
-   - You can check these mailboxes later via SOGo or Roundcube at `https://mailcow.localhost/SOGo/`.
+2. The script automatically provisions `demo1@mail.local` and `demo2@mail.local` with password `demo123`. You can verify or manage them by visiting `https://mailcow.localhost` (default admin credentials `admin` / `moohoo`). Check these mailboxes later via SOGo or Roundcube at `https://mailcow.localhost/SOGo/`.
 
 3. Configure the app to use Mailcow's SMTP service:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add `--mail` to the script to automatically clone Mailcow (initializing its help
 ./start_demo.sh --mail
 ```
 
-By default the script probes for a free `/24` within the `172.30.0.0/16` range by temporarily creating and removing Docker networks, avoiding clashes with both Docker and host subnets. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network (e.g. `10.99.0`). In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (no trailing `.0`) because the compose file appends `.0/24` automatically. If the script still cannot find a free subnet, specify a different range and rerun it.
+By default the script probes for a free `/24` within the `172.30.0.0/16` range by temporarily creating and removing Docker networks, avoiding clashes with both Docker and host subnets. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network with or without a trailing `.0` (e.g. `10.99.0` or `10.99.0.0`). The script normalizes this and writes only the base network to `mailcow.conf` (no trailing `.0`) because the compose file appends `.0/24` automatically. If the script still cannot find a free subnet, specify a different range and rerun it.
 
 If a network named `mailcowdockerized_mailcow-network` is already present, the script assumes Mailcow is running and skips the automatic setup.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run the demo with a single script that installs uv, syncs dependencies, and laun
 ./start_demo.sh
 ```
 
-Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
+Add `--mail` to the script to automatically clone Mailcow (initializing its helper scripts), start a local stack, seed it with two demo inboxes (`demo1@mail.local` and `demo2@mail.local`, password `demo123`), and configure the app to relay through it. If the `addmailuser` helper isn't present, the script fetches it from Mailcow's repository so the demo accounts are still created. The script supplies default answers (`mail.local` FQDN, `UTC` timezone) to Mailcow's setup so it runs without prompts. Set `MAILCOW_HOSTNAME` or `MAILCOW_TZ` before running if you need different values. This requires Docker and docker compose:
 
 ```bash
 ./start_demo.sh --mail

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Add `--mail` to the script to automatically clone and start a local Mailcow stac
 ./start_demo.sh --mail
 ```
 
-By default the script assigns Mailcow to the `172.30.1.0/24` subnet to avoid conflicts with existing Docker networks. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR range like `10.99.0.0/24` (and optionally `MAILCOW_IPV4_ADDRESS`) before running if your environment requires a different range. In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (e.g. `172.30.1` for the default) because the compose file appends `.0/24` automatically.
+By default the script scans for a free `/24` within the `172.30.0.0/16` range to avoid clashes with existing Docker networks. Override this by setting `MAILCOW_IPV4_NETWORK` to a CIDR (e.g. `10.99.0.0/24`) or a base network (e.g. `10.99.0`). In `mailcow.conf`, `IPV4_NETWORK` should contain only the base network (no trailing `.0`) because the compose file appends `.0/24` automatically. If `docker compose` still reports a subnet overlap, choose a different range and rerun the script.
 
 Press `Ctrl+C` when you're finished with the demo; the script automatically shuts down the Mailcow stack and removes its network to prevent conflicts on the next run.
 

--- a/email_summarizer_app.py
+++ b/email_summarizer_app.py
@@ -100,6 +100,19 @@ def render_summary(text: str) -> None:
     )
 
 
+@st.cache_data
+def summarize(text: str, max_len: int) -> str | None:
+    """Return a cached summary for ``text`` up to ``max_len`` tokens."""
+
+    summarizer = get_summarizer()
+    if summarizer is None:
+        return None
+
+    return summarizer(text, max_length=max_len, min_length=20, do_sample=False)[0][
+        "summary_text"
+    ]
+
+
 def _extract_recipients(text: str) -> set[str]:
     """Return all email addresses targeted by SEND EMAIL directives."""
 
@@ -190,15 +203,10 @@ def main() -> None:
     with col1:
         st.subheader("Original Email")
         render_email(email)
-
-    summarizer = get_summarizer()
-    if summarizer is None:
-        return
-
     with st.spinner("Summarizing..."):
-        summary = summarizer(
-            email["Body"], max_length=max_len, min_length=20, do_sample=False
-        )[0]["summary_text"]
+        summary = summarize(email["Body"], max_len)
+    if summary is None:
+        return
 
     maybe_send_email(email["Body"], summary)
 

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -12,6 +12,7 @@ else
 fi
 
 MAIL=false
+STARTED_MAILCOW=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mail)
@@ -26,7 +27,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 cleanup() {
-  if [ "$MAIL" = true ] && [ -d mailcow-dockerized ]; then
+  if [ "$STARTED_MAILCOW" = true ]; then
     (cd mailcow-dockerized && docker compose down >/dev/null 2>&1 || true)
   fi
 }
@@ -44,88 +45,93 @@ fi
 uv sync
 
 if [ "$MAIL" = true ]; then
-  if [ ! -d mailcow-dockerized ]; then
-    git clone https://github.com/mailcow/mailcow-dockerized
-  fi
-  (
-    cd mailcow-dockerized
-    if [ ! -f mailcow.conf ]; then
-      export MAILCOW_HOSTNAME=mail.local
-      export MAILCOW_TZ=UTC
-      export DOCKER_COMPOSE_VERSION=native
-      # BusyBox cp warns on the non-portable -n flag used in mailcow's
-      # generate_config.sh and can terminate this script due to set -e.
-      # Replace it with the POSIX-compliant --update=none option before
-      # running the config generator.
-      sed -i 's/cp -n/cp --update=none/' generate_config.sh
-      yes "" | ./generate_config.sh >/dev/null
+  if docker network inspect mailcowdockerized_mailcow-network >/dev/null 2>&1; then
+    echo "Mailcow network already exists; skipping Mailcow setup."
+  else
+    if [ ! -d mailcow-dockerized ]; then
+      git clone https://github.com/mailcow/mailcow-dockerized
     fi
-
-    # Choose a non-conflicting subnet for Mailcow's bridge network. The network
-    # may be supplied via MAILCOW_IPV4_NETWORK as either a CIDR (e.g.
-    # 192.168.10.0/24) or just the network base (e.g. 192.168.10). When no
-    # network is provided, probe for the first free /24 within 172.30.0.0/16 by
-    # attempting to create a temporary Docker network.
-
-    choose_subnet() {
-      if [ -n "${MAILCOW_IPV4_NETWORK:-}" ]; then
-        local cidr="$MAILCOW_IPV4_NETWORK"
-        [[ "$cidr" != */* ]] && cidr="${cidr}/24"
-        echo "$cidr"
-        return 0
+    (
+      cd mailcow-dockerized
+      if [ ! -f mailcow.conf ]; then
+        export MAILCOW_HOSTNAME=mail.local
+        export MAILCOW_TZ=UTC
+        export DOCKER_COMPOSE_VERSION=native
+        # BusyBox cp warns on the non-portable -n flag used in mailcow's
+        # generate_config.sh and can terminate this script due to set -e.
+        # Replace it with the POSIX-compliant --update=none option before
+        # running the config generator.
+        sed -i 's/cp -n/cp --update=none/' generate_config.sh
+        yes "" | ./generate_config.sh >/dev/null
       fi
-      for i in $(seq 0 255); do
-        local cidr="172.30.${i}.0/24"
-        if docker network create mailcow-probe --subnet "$cidr" >/dev/null 2>&1; then
-          docker network rm mailcow-probe >/dev/null 2>&1 || true
+
+      # Choose a non-conflicting subnet for Mailcow's bridge network. The network
+      # may be supplied via MAILCOW_IPV4_NETWORK as either a CIDR (e.g.
+      # 192.168.10.0/24) or just the network base (e.g. 192.168.10). When no
+      # network is provided, probe for the first free /24 within 172.30.0.0/16 by
+      # attempting to create a temporary Docker network.
+
+      choose_subnet() {
+        if [ -n "${MAILCOW_IPV4_NETWORK:-}" ]; then
+          local cidr="$MAILCOW_IPV4_NETWORK"
+          [[ "$cidr" != */* ]] && cidr="${cidr}/24"
           echo "$cidr"
           return 0
         fi
-      done
-      return 1
-    }
+        for i in $(seq 0 255); do
+          local cidr="172.30.${i}.0/24"
+          if docker network create mailcow-probe --subnet "$cidr" >/dev/null 2>&1; then
+            docker network rm mailcow-probe >/dev/null 2>&1 || true
+            echo "$cidr"
+            return 0
+          fi
+        done
+        return 1
+      }
 
-    IPV4_CIDR=$(choose_subnet) || {
-      echo "Could not find a free subnet in 172.30.0.0/16." >&2
-      echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
-      exit 1
-    }
+      IPV4_CIDR=$(choose_subnet) || {
+        echo "Could not find a free subnet in 172.30.0.0/16." >&2
+        echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
+        exit 1
+      }
 
-    IPV4_NETWORK="${IPV4_CIDR%/*}"
-    IPV4_PREFIX="${IPV4_CIDR#*/}"
-    IPV4_HOST_BASE="${IPV4_NETWORK%.*}"
-    IPV4_ADDRESS="${MAILCOW_IPV4_ADDRESS:-${IPV4_HOST_BASE}.1}"
-    # Mailcow expects IPV4_NETWORK without a trailing .0; the compose file
-    # appends ".0/24" when defining the bridge subnet. Using the host base
-    # avoids generating malformed values like 172.30.1.0.0/24.
-    sed -i "s/^IPV4_NETWORK=.*/IPV4_NETWORK=${IPV4_HOST_BASE}/" mailcow.conf
-    sed -i "s/^IPV4_NETWORK_PREFIX=.*/IPV4_NETWORK_PREFIX=${IPV4_PREFIX}/" mailcow.conf
-    sed -i "s/^IPV4_ADDRESS=.*/IPV4_ADDRESS=${IPV4_ADDRESS}/" mailcow.conf
+      IPV4_NETWORK="${IPV4_CIDR%/*}"
+      IPV4_PREFIX="${IPV4_CIDR#*/}"
+      IPV4_HOST_BASE="${IPV4_NETWORK%.*}"
+      IPV4_ADDRESS="${MAILCOW_IPV4_ADDRESS:-${IPV4_HOST_BASE}.1}"
+      # Mailcow expects IPV4_NETWORK without a trailing .0; the compose file
+      # appends ".0/24" when defining the bridge subnet. Using the host base
+      # avoids generating malformed values like 172.30.1.0.0/24.
+      sed -i "s/^IPV4_NETWORK=.*/IPV4_NETWORK=${IPV4_HOST_BASE}/" mailcow.conf
+      sed -i "s/^IPV4_NETWORK_PREFIX=.*/IPV4_NETWORK_PREFIX=${IPV4_PREFIX}/" mailcow.conf
+      sed -i "s/^IPV4_ADDRESS=.*/IPV4_ADDRESS=${IPV4_ADDRESS}/" mailcow.conf
 
-    docker compose down >/dev/null 2>&1 || true
-    if ! docker compose up -d; then
-      echo "Failed to start Mailcow; subnet ${IPV4_CIDR} may overlap with an existing network." >&2
-      echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
-      exit 1
-    fi
-    add_user_script=""
-    for candidate in \
-      "./helper-scripts/addmailuser.sh" \
-      "./helper-scripts/addmailuser" \
-      "./addmailuser.sh" \
-      "./addmailuser"; do
-      if [ -x "$candidate" ]; then
-        add_user_script="$candidate"
-        break
+      docker compose down >/dev/null 2>&1 || true
+      if ! docker compose up -d; then
+        echo "Failed to start Mailcow; subnet ${IPV4_CIDR} may overlap with an existing network." >&2
+        echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
+        exit 1
       fi
-    done
-    if [ -n "$add_user_script" ]; then
-      "$add_user_script" demo1@mail.local demo123
-      "$add_user_script" demo2@mail.local demo123
-    else
-      echo "Could not find addmailuser helper script" >&2
-    fi
-  )
+      add_user_script=""
+      for candidate in \
+        "./helper-scripts/addmailuser.sh" \
+        "./helper-scripts/addmailuser" \
+        "./addmailuser.sh" \
+        "./addmailuser"; do
+        if [ -x "$candidate" ]; then
+          add_user_script="$candidate"
+          break
+        fi
+      done
+      if [ -n "$add_user_script" ]; then
+        "$add_user_script" demo1@mail.local demo123
+        "$add_user_script" demo2@mail.local demo123
+      else
+        echo "Could not find addmailuser helper script" >&2
+      fi
+    )
+    STARTED_MAILCOW=true
+  fi
   export SMTP_HOST=localhost
   export SMTP_PORT=587
   export SMTP_USER=demo1@mail.local

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Determine a Python interpreter. Prefer python3 but fall back to python.
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "Python 3 is required but was not found" >&2
+  exit 1
+fi
+
 MAIL=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,7 +34,7 @@ trap cleanup EXIT
 
 if ! command -v uv >/dev/null 2>&1; then
   echo "uv not found; installing with pip"
-  python -m pip install --user uv
+  "$PYTHON" -m pip install --user uv
 fi
 
 if [ ! -d ".venv" ]; then
@@ -59,7 +69,7 @@ if [ "$MAIL" = true ]; then
       IPV4_CIDR="$MAILCOW_IPV4_NETWORK"
       [[ "$IPV4_CIDR" != */* ]] && IPV4_CIDR="${IPV4_CIDR}/24"
     else
-      IPV4_CIDR=$(python <<'PY'
+      IPV4_CIDR=$($PYTHON <<'PY'
 import ipaddress, json, subprocess
 subnets=set()
 try:

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -108,11 +108,18 @@ if [ "$MAIL" = true ]; then
       echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
       exit 1
     fi
-    add_user_script="./helper-scripts/addmailuser"
-    if [ ! -x "$add_user_script" ]; then
-      add_user_script="./addmailuser"
-    fi
-    if [ -x "$add_user_script" ]; then
+    add_user_script=""
+    for candidate in \
+      "./helper-scripts/addmailuser.sh" \
+      "./helper-scripts/addmailuser" \
+      "./addmailuser.sh" \
+      "./addmailuser"; do
+      if [ -x "$candidate" ]; then
+        add_user_script="$candidate"
+        break
+      fi
+    done
+    if [ -n "$add_user_script" ]; then
       "$add_user_script" demo1@mail.local demo123
       "$add_user_script" demo2@mail.local demo123
     else

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -122,7 +122,7 @@ if [ "$MAIL" = true ]; then
         fi
       done
       if [ -z "$add_user_script" ]; then
-        add_user_script=$(find . -name 'addmailuser*' -type f 2>/dev/null | head -n1 || true)
+        add_user_script=$(find . -type f \( -name addmailuser -o -name addmailuser.sh \) -print -quit 2>/dev/null || true)
       fi
       if [ -n "$add_user_script" ]; then
         bash "$add_user_script" demo1@mail.local demo123

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -112,20 +112,11 @@ if [ "$MAIL" = true ]; then
         echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
         exit 1
       fi
-      add_user_script=""
-      for candidate in \
-        "./helper-scripts/addmailuser.sh" \
-        "./helper-scripts/addmailuser" \
-        "./addmailuser.sh" \
-        "./addmailuser"; do
-        if [ -x "$candidate" ]; then
-          add_user_script="$candidate"
-          break
-        fi
-      done
+      # Locate the addmailuser helper script even if it lacks execute permissions.
+      add_user_script=$(find . -name 'addmailuser*' -type f -print 2>/dev/null | head -n1 || true)
       if [ -n "$add_user_script" ]; then
-        "$add_user_script" demo1@mail.local demo123
-        "$add_user_script" demo2@mail.local demo123
+        bash "$add_user_script" demo1@mail.local demo123
+        bash "$add_user_script" demo2@mail.local demo123
       else
         echo "Could not find addmailuser helper script" >&2
       fi

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -114,15 +114,9 @@ if [ "$MAIL" = true ]; then
         exit 1
       fi
       # Locate the addmailuser helper script even if it lacks execute permissions.
-      add_user_script=""
-      for candidate in helper-scripts/addmailuser helper-scripts/addmailuser.sh addmailuser; do
-        if [ -f "$candidate" ]; then
-          add_user_script="$candidate"
-          break
-        fi
-      done
+      add_user_script=$(find helper-scripts -maxdepth 1 -type f -name 'addmailuser*' -print -quit 2>/dev/null || true)
       if [ -z "$add_user_script" ]; then
-        add_user_script=$(find . -type f \( -name addmailuser -o -name addmailuser.sh \) -print -quit 2>/dev/null || true)
+        add_user_script=$(find . -type f -name 'addmailuser*' -print -quit 2>/dev/null || true)
       fi
       if [ -n "$add_user_script" ]; then
         bash "$add_user_script" demo1@mail.local demo123

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -51,6 +51,7 @@ if [ "$MAIL" = true ]; then
     if [ ! -d mailcow-dockerized ]; then
       git clone https://github.com/mailcow/mailcow-dockerized
     fi
+    git -C mailcow-dockerized submodule update --init --recursive >/dev/null 2>&1 || true
     (
       cd mailcow-dockerized
       if [ ! -f mailcow.conf ]; then
@@ -113,7 +114,16 @@ if [ "$MAIL" = true ]; then
         exit 1
       fi
       # Locate the addmailuser helper script even if it lacks execute permissions.
-      add_user_script=$(find . -name 'addmailuser*' -type f -print 2>/dev/null | head -n1 || true)
+      add_user_script=""
+      for candidate in helper-scripts/addmailuser helper-scripts/addmailuser.sh addmailuser; do
+        if [ -f "$candidate" ]; then
+          add_user_script="$candidate"
+          break
+        fi
+      done
+      if [ -z "$add_user_script" ]; then
+        add_user_script=$(find . -name 'addmailuser*' -type f 2>/dev/null | head -n1 || true)
+      fi
       if [ -n "$add_user_script" ]; then
         bash "$add_user_script" demo1@mail.local demo123
         bash "$add_user_script" demo2@mail.local demo123

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -117,40 +117,7 @@ if [ "$MAIL" = true ]; then
         echo "Specify MAILCOW_IPV4_NETWORK with a free CIDR range and try again." >&2
         exit 1
       fi
-      # Locate the addmailuser helper script even if it lacks execute
-      # permissions. Prefer a direct path inside helper-scripts/, fall back to a
-      # repo-wide search and, if still missing, attempt to download it from
-      # upstream so demo inboxes can be created.
-      add_user_script=""
-      for path in helper-scripts/addmailuser helper-scripts/addmailuser.sh; do
-        if [ -f "$path" ]; then
-          add_user_script="$path"
-          break
-        fi
-      done
-      if [ -z "$add_user_script" ]; then
-        add_user_script=$(find . -type f -name 'addmailuser*' -print -quit 2>/dev/null || true)
-      fi
-      if [ -z "$add_user_script" ]; then
-        tmp_script=$(mktemp)
-        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo master)
-        for name in addmailuser addmailuser.sh; do
-          url="https://raw.githubusercontent.com/mailcow/mailcow-dockerized/${branch}/helper-scripts/${name}"
-          if curl -fsSL "$url" -o "$tmp_script"; then
-            add_user_script="$tmp_script"
-            break
-          fi
-        done
-        if [ -z "$add_user_script" ]; then
-          rm -f "$tmp_script"
-        fi
-      fi
-      if [ -n "$add_user_script" ]; then
-        bash "$add_user_script" demo1@mail.local demo123
-        bash "$add_user_script" demo2@mail.local demo123
-      else
-        echo "Could not find addmailuser helper script" >&2
-      fi
+      echo "Mailcow started. Create demo1@mail.local and demo2@mail.local with password demo123 via the Web UI or API."
     )
     STARTED_MAILCOW=true
   fi

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -129,9 +129,15 @@ if [ "$MAIL" = true ]; then
       fi
       if [ -z "$add_user_script" ]; then
         tmp_script=$(mktemp)
-        if curl -fsSL "https://raw.githubusercontent.com/mailcow/mailcow-dockerized/master/helper-scripts/addmailuser" -o "$tmp_script"; then
-          add_user_script="$tmp_script"
-        else
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo master)
+        for name in addmailuser addmailuser.sh; do
+          url="https://raw.githubusercontent.com/mailcow/mailcow-dockerized/${branch}/helper-scripts/${name}"
+          if curl -fsSL "$url" -o "$tmp_script"; then
+            add_user_script="$tmp_script"
+            break
+          fi
+        done
+        if [ -z "$add_user_script" ]; then
           rm -f "$tmp_script"
         fi
       fi

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -74,9 +74,13 @@ if [ "$MAIL" = true ]; then
 
       choose_subnet() {
         if [ -n "${MAILCOW_IPV4_NETWORK:-}" ]; then
-          local cidr="$MAILCOW_IPV4_NETWORK"
-          [[ "$cidr" != */* ]] && cidr="${cidr}/24"
-          echo "$cidr"
+          local net="$MAILCOW_IPV4_NETWORK"
+          if [[ "$net" == */* ]]; then
+            echo "$net"
+          else
+            net="${net%.0}"
+            echo "${net}.0/24"
+          fi
           return 0
         fi
         for i in $(seq 0 255); do

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -61,7 +61,10 @@ if [ "$MAIL" = true ]; then
     IPV4_PREFIX="${IPV4_CIDR#*/}"
     IPV4_HOST_BASE="${IPV4_NETWORK%.*}"
     IPV4_ADDRESS="${MAILCOW_IPV4_ADDRESS:-${IPV4_HOST_BASE}.1}"
-    sed -i "s/^IPV4_NETWORK=.*/IPV4_NETWORK=${IPV4_NETWORK}/" mailcow.conf
+    # Mailcow expects IPV4_NETWORK without a trailing .0; the compose file
+    # appends ".0/24" when defining the bridge subnet. Using the host base
+    # avoids generating malformed values like 172.30.1.0.0/24.
+    sed -i "s/^IPV4_NETWORK=.*/IPV4_NETWORK=${IPV4_HOST_BASE}/" mailcow.conf
     sed -i "s/^IPV4_NETWORK_PREFIX=.*/IPV4_NETWORK_PREFIX=${IPV4_PREFIX}/" mailcow.conf
     sed -i "s/^IPV4_ADDRESS=.*/IPV4_ADDRESS=${IPV4_ADDRESS}/" mailcow.conf
 


### PR DESCRIPTION
## Summary
- ensure start_demo.sh writes IPV4_NETWORK without trailing .0 to avoid 172.30.1.0.0/24 error
- document that mailcow.conf uses base network only and clarify README setup instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6897639c76b0832cbac5869ed6ad67eb