### PR TITLE
Include LangChain in demo dependencies

### DIFF
--- a/email_summarizer_app.py
+++ b/email_summarizer_app.py
@@ -16,10 +16,14 @@ from email.message import EmailMessage
 
 import streamlit as st
 try:  # pragma: no cover - optional dependency
-    from langchain.embeddings import HuggingFaceEmbeddings
-    from langchain.vectorstores import FAISS
-except ModuleNotFoundError:  # pragma: no cover - missing langchain
-    HuggingFaceEmbeddings = FAISS = None  # type: ignore
+    from langchain_community.embeddings import HuggingFaceEmbeddings
+    from langchain_community.vectorstores import FAISS
+except ModuleNotFoundError:  # pragma: no cover - compatibility fallback
+    try:
+        from langchain.embeddings import HuggingFaceEmbeddings
+        from langchain.vectorstores import FAISS
+    except ModuleNotFoundError:  # pragma: no cover - missing langchain
+        HuggingFaceEmbeddings = FAISS = None  # type: ignore
 
 try:  # pragma: no cover - optional dependency
     from transformers import pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,6 @@ dependencies = [
     "streamlit",
     "transformers",
     "torch",
+    "langchain",
+    "faiss-cpu",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,6 @@ dependencies = [
     "transformers",
     "torch",
     "langchain",
+    "langchain-community",
     "faiss-cpu",
 ]


### PR DESCRIPTION
## Summary
- Ensure Streamlit demo installs LangChain and FAISS so RAG features are enabled

## Testing
- `python -m py_compile email_summarizer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9926a30832cb833d8aaf40c7587