### PR TITLE
Handle missing FAISS index in load_vectorstore

### DIFF
--- a/email_summarizer_app.py
+++ b/email_summarizer_app.py
@@ -106,48 +106,47 @@ def get_summarizer():
 
 @st.cache_resource
 def load_vectorstore():
-    """Load or initialize the FAISS vector store used for RAG."""
+    """Load or initialize the FAISS vector store used for RAG.
+
+    When the pre-built index is missing, we create an empty store so the
+    rest of the demo can continue to function.
+    """
     if FAISS is None or HuggingFaceEmbeddings is None:
         st.sidebar.warning("LangChain not installed; RAG demo disabled.")
         return None
 
-    try:
+    # Ensure the sentence transformers package is available for the embedding
+    try:  # pragma: no cover - optional dependency
         import sentence_transformers  # type: ignore  # noqa: F401
-    except Exception as exc:
-
-        embeddings = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/all-MiniLM-L6-v2"
-        )
-    except ModuleNotFoundError as exc:
-
-
+    except Exception as exc:  # pragma: no cover - dependency failure
+        st.sidebar.error("`sentence-transformers` is required for embeddings.")
+        st.sidebar.exception(exc)
+        return None
 
     try:
         embeddings = HuggingFaceEmbeddings(
             model_name="sentence-transformers/all-MiniLM-L6-v2"
         )
     except Exception as exc:  # pragma: no cover - embedding init failure
+        st.sidebar.error("Failed to load embeddings model.")
+        st.sidebar.exception(exc)
+        return None
 
-
+    # Try to load an existing FAISS index from disk
     try:
         return FAISS.load_local(
             str(VECTOR_STORE_DIR), embeddings, allow_dangerous_deserialization=True
         )
     except Exception:
+        # No existing index found; create an empty one
         VECTOR_STORE_DIR.mkdir(parents=True, exist_ok=True)
         try:
             import faiss  # type: ignore
             from langchain.docstore import InMemoryDocstore  # type: ignore
 
-
-            sample = embeddings.embed_query("")
-            if not sample:
-                raise ValueError("Empty embedding returned")
-            dimension = len(sample)
-
-            dimension = len(embeddings.embed_query(""))
-
-            index = faiss.IndexFlatL2(dimension)
+            # Determine embedding dimensionality
+            sample = embeddings.embed_query("placeholder")
+            index = faiss.IndexFlatL2(len(sample))
             return FAISS(
                 embedding_function=embeddings,
                 index=index,

--- a/email_summarizer_app.py
+++ b/email_summarizer_app.py
@@ -16,8 +16,11 @@ from email.message import EmailMessage
 
 import streamlit as st
 try:  # pragma: no cover - optional dependency
-    from langchain.embeddings import HuggingFaceEmbeddings
     from langchain.vectorstores import FAISS
+    try:  # Prefer the standalone package to avoid deprecation warnings
+        from langchain_huggingface import HuggingFaceEmbeddings
+    except ModuleNotFoundError:  # fall back to deprecated import
+        from langchain.embeddings import HuggingFaceEmbeddings
 except ModuleNotFoundError:  # pragma: no cover - missing langchain
     HuggingFaceEmbeddings = FAISS = None  # type: ignore
 

--- a/email_summarizer_app.py
+++ b/email_summarizer_app.py
@@ -17,10 +17,7 @@ from email.message import EmailMessage
 import streamlit as st
 try:  # pragma: no cover - optional dependency
     from langchain.vectorstores import FAISS
-    try:  # Prefer the standalone package to avoid deprecation warnings
-        from langchain_huggingface import HuggingFaceEmbeddings
-    except ModuleNotFoundError:  # fall back to deprecated import
-        from langchain.embeddings import HuggingFaceEmbeddings
+    from langchain_huggingface import HuggingFaceEmbeddings
 except ModuleNotFoundError:  # pragma: no cover - missing langchain
     HuggingFaceEmbeddings = FAISS = None  # type: ignore
 
@@ -118,14 +115,6 @@ def load_vectorstore():
         st.sidebar.warning("LangChain not installed; RAG demo disabled.")
         return None
 
-    # Ensure the sentence transformers package is available for the embedding
-    try:  # pragma: no cover - optional dependency
-        import sentence_transformers  # type: ignore  # noqa: F401
-    except Exception as exc:  # pragma: no cover - dependency failure
-        st.sidebar.error("`sentence-transformers` is required for embeddings.")
-        st.sidebar.exception(exc)
-        return None
-
     try:
         embeddings = HuggingFaceEmbeddings(
             model_name="sentence-transformers/all-MiniLM-L6-v2"
@@ -141,25 +130,18 @@ def load_vectorstore():
             str(VECTOR_STORE_DIR), embeddings, allow_dangerous_deserialization=True
         )
     except Exception:
-        # No existing index found; create an empty one
         VECTOR_STORE_DIR.mkdir(parents=True, exist_ok=True)
-        try:
-            import faiss  # type: ignore
-            from langchain.docstore import InMemoryDocstore  # type: ignore
+        import faiss  # type: ignore
+        from langchain.docstore import InMemoryDocstore  # type: ignore
 
-            # Determine embedding dimensionality
-            sample = embeddings.embed_query("placeholder")
-            index = faiss.IndexFlatL2(len(sample))
-            return FAISS(
-                embedding_function=embeddings,
-                index=index,
-                docstore=InMemoryDocstore({}),
-                index_to_docstore_id={},
-            )
-        except Exception as exc:  # pragma: no cover - faiss init failure
-            st.sidebar.error("Failed to initialize empty vector store.")
-            st.sidebar.exception(exc)
-            return None
+        dim = len(embeddings.embed_query("placeholder"))
+        index = faiss.IndexFlatL2(dim)
+        return FAISS(
+            embedding_function=embeddings,
+            index=index,
+            docstore=InMemoryDocstore({}),
+            index_to_docstore_id={},
+        )
 
 
 def add_vulnerability_prompt(store) -> None:


### PR DESCRIPTION
## Summary
- create load_vectorstore that initializes an empty FAISS index when the on-disk store is missing
- improve error handling for missing dependencies and embedding model failures

## Testing
- `python -m py_compile email_summarizer_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c4fde7c832cb287dcd3c41caee4